### PR TITLE
Fix timeline line display

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -871,14 +871,22 @@ span {
   line-height: 1.6;
 }
 
-.timeline-item:not(:last-child)::before {
+.timeline-item:not(:last-child)::before,
+.timeline-item:only-child::before {
   content: "";
   position: absolute;
   top: -25px;
   left: -30px;
   width: 1px;
-  height: calc(100% + 50px);
   background: var(--jet);
+}
+
+.timeline-item:not(:last-child)::before {
+  height: calc(100% + 50px);
+}
+
+.timeline-item:only-child::before {
+  height: 30px;
 }
 
 .timeline-item::after {
@@ -1468,7 +1476,8 @@ textarea.form-input::-webkit-resizer { display: none; }
 
   .timeline-list { margin-left: 65px; }
 
-  .timeline-item:not(:last-child)::before { left: -40px; }
+  .timeline-item:not(:last-child)::before,
+  .timeline-item:only-child::before { left: -40px; }
 
   .timeline-item::after {
     height: 8px;


### PR DESCRIPTION
## Summary
- ensure timeline marker line renders when only one item is present and doesn't overshoot dot

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c4ddd55fc83238c097daf5c3e899e